### PR TITLE
fix: restrict chip options and improve connection prompts

### DIFF
--- a/scripts/chip-support-test.js
+++ b/scripts/chip-support-test.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+
+const chips = await import('../src/config/chips.ts');
+
+const expectedSupport = {
+  SF32LB52: {
+    memories: ['NOR', 'NAND', 'SD'],
+    interfaces: ['UART'],
+  },
+  SF32LB55: {
+    memories: ['NOR', 'SD'],
+    interfaces: ['UART'],
+  },
+  SF32LB56: {
+    memories: ['NOR'],
+    interfaces: ['UART', 'USB'],
+  },
+  SF32LB58: {
+    memories: ['NOR'],
+    interfaces: ['UART', 'USB'],
+  },
+};
+
+for (const [chipId, support] of Object.entries(expectedSupport)) {
+  assert.deepEqual(chips.getSupportedMemoryTypes(chipId), support.memories, `${chipId} memory support mismatch`);
+  assert.deepEqual(chips.getSupportedInterfaces(chipId), support.interfaces, `${chipId} interface support mismatch`);
+}
+
+assert.equal(chips.isInterfaceImplemented('UART'), true, 'UART should be implemented');
+assert.equal(chips.isInterfaceImplemented('USB'), true, 'USB should be selectable for supported chips');
+
+console.log('chip support matrix ok');

--- a/src-tauri/src/commands/device.rs
+++ b/src-tauri/src/commands/device.rs
@@ -2,10 +2,27 @@ use crate::progress::TauriProgressCallback;
 use crate::state::AppState;
 use crate::types::{DeviceConfig, PortInfo};
 use crate::utils::{create_tool_instance_with_progress, list_serial_ports};
+use chrono::Local;
+use serde_json::json;
 use sftool_lib::progress::ProgressSinkArc;
 use sftool_lib::CancelToken;
 use std::sync::{Arc, Mutex};
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Emitter, State};
+
+fn emit_system_log(app_handle: &AppHandle, message: &str, important: bool) {
+    let timestamp = Local::now().format("%H:%M:%S");
+    let formatted_message = format!("[{}] {}", timestamp, message);
+
+    if let Err(error) = app_handle.emit(
+        "log-message",
+        json!({
+            "message": formatted_message,
+            "important": important,
+        }),
+    ) {
+        eprintln!("Failed to emit system log message: {error}");
+    }
+}
 
 #[tauri::command]
 pub fn get_serial_ports() -> Result<Vec<PortInfo>, String> {
@@ -39,11 +56,21 @@ pub async fn connect_device(
     };
 
     // 创建 Tauri 进度回调
-    let progress_callback: ProgressSinkArc = Arc::new(TauriProgressCallback::new(app_handle));
+    let progress_callback: ProgressSinkArc =
+        Arc::new(TauriProgressCallback::new(app_handle.clone()));
 
     // 创建带进度回调的工具实例
-    let tool =
-        create_tool_instance_with_progress(&device_config, progress_callback, CancelToken::new())?;
+    let tool = match create_tool_instance_with_progress(
+        &device_config,
+        progress_callback,
+        CancelToken::new(),
+    ) {
+        Ok(tool) => tool,
+        Err(error) => {
+            emit_system_log(&app_handle, &format!("连接失败: {error}"), true);
+            return Err(error);
+        }
+    };
 
     // 保存设备配置和工具实例到状态
     let mut app_state = state.lock().unwrap();

--- a/src-tauri/src/utils/tool_factory.rs
+++ b/src-tauri/src/utils/tool_factory.rs
@@ -1,11 +1,20 @@
 use crate::types::DeviceConfig;
 use crate::utils::stub_ops::prepare_stub_path;
-use serialport::SerialPort;
+use serialport::{ErrorKind as SerialPortErrorKind, SerialPort};
 use sftool_lib::{
     create_sifli_tool, progress::ProgressSinkArc, BeforeOperation, CancelToken, ChipType,
     EraseFlashParams, EraseFlashTrait, EraseRegionParams, ReadFlashParams, ReadFlashTrait,
     SifliTool, SifliToolBase, SifliToolTrait, WriteFlashParams, WriteFlashTrait,
 };
+use std::any::Any;
+use std::io::ErrorKind as IoErrorKind;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::thread;
+use std::time::Duration;
+
+const CONNECT_ATTEMPTS: i8 = 3;
+const SERIAL_OPEN_RETRY_ATTEMPTS: u8 = 10;
+const SERIAL_OPEN_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 struct ToolWithStubOwner {
     inner: Box<dyn SifliTool>,
@@ -70,56 +79,169 @@ impl SifliTool for ToolWithStubOwner {
     }
 }
 
-/// 创建 SifliTool 实例（无进度回调）
-pub fn create_tool_instance(config: &DeviceConfig) -> Result<Box<dyn SifliTool>, String> {
-    // 解析芯片类型
-    let chip_type = match config.chip_type.to_uppercase().as_str() {
-        "SF32LB52" => ChipType::SF32LB52,
-        "SF32LB55" => ChipType::SF32LB55,
-        "SF32LB56" => ChipType::SF32LB56,
-        "SF32LB58" => ChipType::SF32LB58,
-        _ => return Err(format!("不支持的芯片型号: {}", config.chip_type)),
-    };
-
-    let external_stub_path = if !config.external_stub_path.is_empty() {
-        Some(config.external_stub_path.clone())
-    } else {
-        None
-    };
-
-    // 创建 SifliToolBase (无进度回调)
-    let base = SifliToolBase::new_with_external_stub(
-        config.port_name.clone(),
-        BeforeOperation::NoReset,
-        config.memory_type.to_lowercase(),
-        config.baud_rate,
-        3,
-        false,
-        sftool_lib::progress::no_op_progress_sink(),
-        external_stub_path,
-    );
-
-    // 创建对应的工具实例
-    let tool = create_sifli_tool(chip_type, base);
-    Ok(tool)
+fn parse_chip_type(chip_type: &str) -> Result<ChipType, String> {
+    match chip_type.to_uppercase().as_str() {
+        "SF32LB52" => Ok(ChipType::SF32LB52),
+        "SF32LB55" => Ok(ChipType::SF32LB55),
+        "SF32LB56" => Ok(ChipType::SF32LB56),
+        "SF32LB58" => Ok(ChipType::SF32LB58),
+        _ => Err(format!("不支持的芯片型号: {}", chip_type)),
+    }
 }
 
-/// 创建带进度回调的 SifliTool 实例
-pub fn create_tool_instance_with_progress(
+fn wait_for_serial_port(port_name: &str, baud_rate: u32) -> Result<(), String> {
+    wait_for_serial_port_with_retry(port_name, SERIAL_OPEN_RETRY_ATTEMPTS, || {
+        serialport::new(port_name, baud_rate)
+            .timeout(Duration::from_millis(200))
+            .open()
+            .map(|_| ())
+    })
+}
+
+fn wait_for_serial_port_with_retry<F>(
+    port_name: &str,
+    max_attempts: u8,
+    mut opener: F,
+) -> Result<(), String>
+where
+    F: FnMut() -> serialport::Result<()>,
+{
+    let attempts = max_attempts.max(1);
+    let mut last_error: Option<serialport::Error> = None;
+
+    for attempt in 1..=attempts {
+        match opener() {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                if attempt == attempts {
+                    return Err(format_serial_open_error(port_name, &error));
+                }
+
+                last_error = Some(error);
+                thread::sleep(SERIAL_OPEN_RETRY_DELAY);
+            }
+        }
+    }
+
+    match last_error {
+        Some(error) => Err(format_serial_open_error(port_name, &error)),
+        None => Err(format!("串口 {} 打开失败：未执行连接尝试", port_name)),
+    }
+}
+
+fn format_serial_open_error(port_name: &str, error: &serialport::Error) -> String {
+    let detail = error.to_string();
+    let detail_lower = detail.to_lowercase();
+    let access_denied = detail_lower.contains("access is denied")
+        || detail_lower.contains("permission denied")
+        || detail_lower.contains("拒绝访问")
+        || detail_lower.contains("权限");
+
+    match error.kind() {
+        SerialPortErrorKind::NoDevice if access_denied => format!(
+            "串口 {} 被占用或权限不足，请关闭其它串口工具后重试。原始错误: {}",
+            port_name, detail
+        ),
+        SerialPortErrorKind::NoDevice => format!(
+            "串口 {} 不可用，可能已断开、端口不存在或被系统占用。原始错误: {}",
+            port_name, detail
+        ),
+        SerialPortErrorKind::InvalidInput => format!(
+            "串口 {} 参数无效，请检查端口名和波特率设置。原始错误: {}",
+            port_name, detail
+        ),
+        SerialPortErrorKind::Io(IoErrorKind::PermissionDenied) => format!(
+            "串口 {} 被占用或权限不足，请关闭其它串口工具后重试。原始错误: {}",
+            port_name, detail
+        ),
+        SerialPortErrorKind::Io(IoErrorKind::NotFound) => format!(
+            "串口 {} 不存在或已断开，请刷新串口列表后重试。原始错误: {}",
+            port_name, detail
+        ),
+        SerialPortErrorKind::Io(IoErrorKind::TimedOut | IoErrorKind::WouldBlock) => {
+            format!(
+                "串口 {} 打开超时，请检查串口驱动或重新插拔设备。原始错误: {}",
+                port_name, detail
+            )
+        }
+        _ if access_denied => format!(
+            "串口 {} 被占用或权限不足，请关闭其它串口工具后重试。原始错误: {}",
+            port_name, detail
+        ),
+        _ => format!("串口 {} 打开失败。原始错误: {}", port_name, detail),
+    }
+}
+
+fn create_sifli_tool_checked(
+    chip_type: ChipType,
+    base: SifliToolBase,
+) -> Result<Box<dyn SifliTool>, String> {
+    catch_unwind(AssertUnwindSafe(|| create_sifli_tool(chip_type, base)))
+        .map_err(format_tool_creation_panic)
+}
+
+fn format_tool_creation_panic(payload: Box<dyn Any + Send>) -> String {
+    let detail = panic_payload_to_string(&payload);
+    let detail_lower = detail.to_lowercase();
+
+    if detail_lower.contains("failed to connect to the chip")
+        || detail_lower.contains("timeout while")
+        || detail_lower.contains("receive timeout")
+        || detail_lower.contains("timed out")
+    {
+        return format!(
+            "连接超时：串口已打开，但芯片未响应。请确认开发板已上电、BOOT/复位操作正确，且芯片型号和接口选择匹配。原始错误: {}",
+            detail
+        );
+    }
+
+    if detail_lower.contains("failed to download stub") {
+        return format!(
+            "Stub 下载失败：串口已打开，但初始化程序下载失败。请检查存储器类型、Stub 配置/外部 Stub 文件和复位方式。原始错误: {}",
+            detail
+        );
+    }
+
+    if detail_lower.contains("access is denied")
+        || detail_lower.contains("permission denied")
+        || detail_lower.contains("拒绝访问")
+    {
+        return format!(
+            "串口被占用或权限不足，请关闭其它串口工具后重试。原始错误: {}",
+            detail
+        );
+    }
+
+    if detail_lower.contains("cannot find")
+        || detail_lower.contains("not found")
+        || detail_lower.contains("no such file")
+    {
+        return format!(
+            "串口不存在或已断开，请刷新串口列表后重试。原始错误: {}",
+            detail
+        );
+    }
+
+    format!("连接失败：工具初始化异常。原始错误: {}", detail)
+}
+
+fn panic_payload_to_string(payload: &(dyn Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
+fn build_tool_base_with_progress(
     config: &DeviceConfig,
     progress_callback: ProgressSinkArc,
     cancel_token: CancelToken,
-) -> Result<Box<dyn SifliTool>, String> {
-    // 解析芯片类型
-    let chip_type = match config.chip_type.to_uppercase().as_str() {
-        "SF32LB52" => ChipType::SF32LB52,
-        "SF32LB55" => ChipType::SF32LB55,
-        "SF32LB56" => ChipType::SF32LB56,
-        "SF32LB58" => ChipType::SF32LB58,
-        _ => return Err(format!("不支持的芯片型号: {}", config.chip_type)),
-    };
+) -> Result<(SifliToolBase, Option<tempfile::NamedTempFile>), String> {
+    let chip_type = parse_chip_type(&config.chip_type)?;
 
-    // parse before/after operation strings into enums
     let before_enum = match config.before_operation.as_str() {
         "default_reset" => BeforeOperation::DefaultReset,
         "no_reset" => BeforeOperation::NoReset,
@@ -143,20 +265,63 @@ pub fn create_tool_instance_with_progress(
     )
     .map_err(|e| format!("准备存根文件失败: {}", e))?;
 
-    // 创建 SifliToolBase (带进度回调)
     let base = SifliToolBase::new_with_external_stub_and_cancel(
         config.port_name.clone(),
         before_enum,
         config.memory_type.to_lowercase(),
         config.baud_rate,
-        1,
+        CONNECT_ATTEMPTS,
         false,
         progress_callback,
         stub_path,
         cancel_token,
     );
 
+    Ok((base, temp_stub_file))
+}
+
+/// 创建 SifliTool 实例（无进度回调）
+pub fn create_tool_instance(config: &DeviceConfig) -> Result<Box<dyn SifliTool>, String> {
+    // 解析芯片类型
+    let chip_type = parse_chip_type(&config.chip_type)?;
+
+    let external_stub_path = if !config.external_stub_path.is_empty() {
+        Some(config.external_stub_path.clone())
+    } else {
+        None
+    };
+
+    // 创建 SifliToolBase (无进度回调)
+    let base = SifliToolBase::new_with_external_stub(
+        config.port_name.clone(),
+        BeforeOperation::NoReset,
+        config.memory_type.to_lowercase(),
+        config.baud_rate,
+        CONNECT_ATTEMPTS,
+        false,
+        sftool_lib::progress::no_op_progress_sink(),
+        external_stub_path,
+    );
+
     // 创建对应的工具实例
-    let tool = create_sifli_tool(chip_type, base);
+    let tool = create_sifli_tool_checked(chip_type, base)?;
+    Ok(tool)
+}
+
+/// 创建带进度回调的 SifliTool 实例
+pub fn create_tool_instance_with_progress(
+    config: &DeviceConfig,
+    progress_callback: ProgressSinkArc,
+    cancel_token: CancelToken,
+) -> Result<Box<dyn SifliTool>, String> {
+    // 解析芯片类型
+    let chip_type = parse_chip_type(&config.chip_type)?;
+    let (base, temp_stub_file) =
+        build_tool_base_with_progress(config, progress_callback.clone(), cancel_token)?;
+
+    wait_for_serial_port(&config.port_name, config.baud_rate)?;
+
+    // 创建对应的工具实例
+    let tool = create_sifli_tool_checked(chip_type, base)?;
     Ok(Box::new(ToolWithStubOwner::new(tool, temp_stub_file)))
 }

--- a/src/components/DeviceConnection.vue
+++ b/src/components/DeviceConnection.vue
@@ -144,28 +144,17 @@
       <div class="mb-2">
         <div class="flex justify-center gap-4">
           <div
+            v-for="interfaceType in interfaceOptions"
+            :key="interfaceType"
             class="flex items-center justify-center cursor-pointer p-2 rounded-lg transition-colors duration-200 w-20 h-10"
-            :class="
-              selectedInterface === 'UART'
-                ? 'bg-primary/20 border border-primary'
-                : 'bg-base-100 hover:bg-base-300/50 border border-base-300'
-            "
-            @click="selectInterface('UART')"
-            :disabled="isConnected || isConnecting"
+            :class="getInterfaceOptionClass(interfaceType)"
+            :title="getInterfaceOptionTitle(interfaceType)"
+            :aria-disabled="isInterfaceOptionDisabled(interfaceType)"
+            @click="selectInterface(interfaceType)"
           >
-            <span class="font-medium" :class="selectedInterface === 'UART' ? 'text-primary' : ''">UART</span>
-          </div>
-          <div
-            class="flex items-center justify-center cursor-pointer p-2 rounded-lg transition-colors duration-200 w-20 h-10"
-            :class="
-              selectedInterface === 'USB'
-                ? 'bg-primary/20 border border-primary'
-                : 'bg-base-100 hover:bg-base-300/50 border border-base-300'
-            "
-            @click="selectInterface('USB')"
-            :disabled="isConnected || isConnecting"
-          >
-            <span class="font-medium" :class="selectedInterface === 'USB' ? 'text-primary' : ''">USB</span>
+            <span class="font-medium" :class="selectedInterface === interfaceType ? 'text-primary' : ''">
+              {{ interfaceType }}
+            </span>
           </div>
         </div>
       </div>
@@ -586,7 +575,7 @@ import { useDeviceStore } from '../stores/deviceStore';
 import type { ResetBeforeMode, ResetAfterMode } from '../stores/deviceStore';
 import { useStubConfigStore } from '../stores/stubConfigStore';
 import { WindowManager } from '../services/windowManager';
-import type { ChipModel } from '../config/chips';
+import type { ChipModel, InterfaceType, MemoryType } from '../config/chips';
 import type { PortInfo, SerialPortsChangedEvent } from '../types/device';
 
 const { t } = useI18n();
@@ -689,6 +678,8 @@ const {
   showMemoryTypeDropdown,
   tempMemoryTypeInput,
   selectedInterface,
+  availableInterfaces,
+  interfaceOptions,
   availablePorts,
   isLoadingPorts,
   selectedPort,
@@ -817,13 +808,41 @@ const selectChip = (chip: ChipModel) => {
 };
 
 // 选择存储器类型
-const selectMemoryType = (memoryType: string) => {
+const selectMemoryType = (memoryType: MemoryType) => {
   deviceStore.setSelectedMemoryType(memoryType);
   deviceStore.setShowMemoryTypeDropdown(false);
 };
 
 // 选择接口类型
-const selectInterface = (interfaceType: string) => {
+const isInterfaceOptionDisabled = (interfaceType: InterfaceType) => {
+  return isConnected.value || isConnecting.value || !availableInterfaces.value.includes(interfaceType);
+};
+
+const getInterfaceOptionClass = (interfaceType: InterfaceType) => {
+  if (isInterfaceOptionDisabled(interfaceType)) {
+    return 'bg-base-200 text-base-content/40 border border-base-300 cursor-not-allowed opacity-60';
+  }
+
+  if (selectedInterface.value === interfaceType) {
+    return 'bg-primary/20 border border-primary';
+  }
+
+  return 'bg-base-100 hover:bg-base-300/50 border border-base-300';
+};
+
+const getInterfaceOptionTitle = (interfaceType: InterfaceType) => {
+  if (!selectedChip.value || availableInterfaces.value.includes(interfaceType)) {
+    return '';
+  }
+
+  return t('deviceConnection.unsupportedInterfaceForChip', {
+    chip: selectedChip.value.name,
+    interface: interfaceType,
+  }) as string;
+};
+
+const selectInterface = (interfaceType: InterfaceType) => {
+  if (isInterfaceOptionDisabled(interfaceType)) return;
   deviceStore.setSelectedInterface(interfaceType);
 };
 

--- a/src/config/chips.ts
+++ b/src/config/chips.ts
@@ -1,26 +1,58 @@
 // 芯片型号配置文件
+export type MemoryType = 'NOR' | 'NAND' | 'SD';
+export type InterfaceType = 'UART' | 'USB';
+
 export interface ChipModel {
   id: string;
   name: string;
+  supportedMemoryTypes: MemoryType[];
+  supportedInterfaces: InterfaceType[];
 }
+
+export const ALL_INTERFACES: InterfaceType[] = ['UART', 'USB'];
 
 export const CHIP_MODELS: ChipModel[] = [
   {
     id: 'SF32LB52',
     name: 'SF32LB52',
+    supportedMemoryTypes: ['NOR', 'NAND', 'SD'],
+    supportedInterfaces: ['UART'],
   },
   {
     id: 'SF32LB55',
     name: 'SF32LB55',
+    supportedMemoryTypes: ['NOR', 'SD'],
+    supportedInterfaces: ['UART'],
   },
   {
     id: 'SF32LB56',
     name: 'SF32LB56',
+    supportedMemoryTypes: ['NOR'],
+    supportedInterfaces: ['UART', 'USB'],
   },
   {
     id: 'SF32LB58',
     name: 'SF32LB58',
+    supportedMemoryTypes: ['NOR'],
+    supportedInterfaces: ['UART', 'USB'],
   },
 ];
+
+export const findChipModel = (chipId?: string | null): ChipModel | null => {
+  if (!chipId) return null;
+  return CHIP_MODELS.find(chip => chip.id === chipId) || null;
+};
+
+export const getSupportedMemoryTypes = (chipId?: string | null): MemoryType[] => {
+  return findChipModel(chipId)?.supportedMemoryTypes || ['NOR'];
+};
+
+export const getSupportedInterfaces = (chipId?: string | null): InterfaceType[] => {
+  return findChipModel(chipId)?.supportedInterfaces || ['UART'];
+};
+
+export const isInterfaceImplemented = (interfaceType: string): boolean => {
+  return interfaceType === 'UART' || interfaceType === 'USB';
+};
 
 export default CHIP_MODELS;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -464,6 +464,7 @@
     "noStorageTypeAvailable": "No memory types available",
     "interfaceSettings": "Interface Settings",
     "interfaceType": "Interface Type",
+    "unsupportedInterfaceForChip": "{chip} does not support the {interface} interface",
     "serialPort": "COM Port",
     "serialPortPlaceholder": "Select or search for a COM port",
     "noPortFound": "No COM port detected",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -464,6 +464,7 @@
     "noStorageTypeAvailable": "无可用存储器类型",
     "interfaceSettings": "接口设置",
     "interfaceType": "接口类型",
+    "unsupportedInterfaceForChip": "{chip} 不支持 {interface} 接口",
     "serialPort": "串口号",
     "serialPortPlaceholder": "请选择或搜索串口",
     "noPortFound": "未检测到串口设备",

--- a/src/stores/deviceStore.ts
+++ b/src/stores/deviceStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import { load } from '@tauri-apps/plugin-store';
-import type { ChipModel } from '../config/chips';
-import { CHIP_MODELS } from '../config/chips';
+import type { ChipModel, InterfaceType, MemoryType } from '../config/chips';
+import { ALL_INTERFACES, CHIP_MODELS, getSupportedInterfaces, getSupportedMemoryTypes } from '../config/chips';
 import type { ConnectionIssue, PortInfo } from '../types/device';
 import { findMatchingPort, isPortAvailable, usbIdentityKey } from '../types/device';
 // 下载/重启行为类型
@@ -33,13 +33,13 @@ export const useDeviceStore = defineStore('device', {
     tempChipInput: 'SF32LB52',
 
     // 存储器类型
-    selectedMemoryType: 'NOR' as string | null,
+    selectedMemoryType: 'NOR' as MemoryType | null,
     memoryTypeInput: 'NOR',
     showMemoryTypeDropdown: false,
     tempMemoryTypeInput: 'NOR',
 
     // 接口设置
-    selectedInterface: 'UART',
+    selectedInterface: 'UART' as InterfaceType,
 
     // 串口设置
     availablePorts: [] as PortInfo[],
@@ -55,15 +55,6 @@ export const useDeviceStore = defineStore('device', {
     tempBaudRateInput: '',
     baudRates: [1000000, 1500000, 3000000, 6000000],
 
-    // 芯片与存储器映射
-    chipMemoryTypes: {
-      SF32LB52: ['NOR', 'NAND', 'SD'],
-      SF32LB56: ['NOR', 'NAND', 'SD'],
-      SF32LB58: ['NOR', 'NAND', 'SD'],
-      SF32LB55: ['NOR', 'SD'],
-      default: ['NOR'],
-    } as Record<string, string[]>,
-
     // 下载行为设置（保存到设备相关设置）
     downloadBehavior: {
       before: 'default_reset' as ResetBeforeMode,
@@ -73,16 +64,29 @@ export const useDeviceStore = defineStore('device', {
 
   getters: {
     // 获取当前芯片可用的存储器类型
-    availableMemoryTypes(): string[] {
+    availableMemoryTypes(): MemoryType[] {
       if (!this.selectedChip) return [];
-      return (
-        this.chipMemoryTypes[this.selectedChip.id as keyof typeof this.chipMemoryTypes] || this.chipMemoryTypes.default
-      );
+      return getSupportedMemoryTypes(this.selectedChip.id);
+    },
+
+    // 获取当前芯片支持的接口类型
+    availableInterfaces(): InterfaceType[] {
+      if (!this.selectedChip) return [];
+      return getSupportedInterfaces(this.selectedChip.id);
+    },
+
+    // 所有接口选项，UI 可据此显示禁用态
+    interfaceOptions(): InterfaceType[] {
+      return ALL_INTERFACES;
+    },
+
+    isSelectedInterfaceSupported(): boolean {
+      return this.availableInterfaces.includes(this.selectedInterface);
     },
 
     // 连接验证
     isConnectionValid(): boolean {
-      if (!this.selectedChip || !this.selectedMemoryType) return false;
+      if (!this.selectedChip || !this.selectedMemoryType || !this.isSelectedInterfaceSupported) return false;
 
       if (this.selectedInterface === 'UART') {
         return !!this.selectedPort && this.selectedPortAvailable && !!this.baudRateInput;
@@ -141,31 +145,43 @@ export const useDeviceStore = defineStore('device', {
       this.selectedChip = chip;
       if (chip) {
         this.chipSearchInput = chip.name;
-        // 重置存储器类型
-        this.selectedMemoryType = null;
-        this.memoryTypeInput = '';
 
-        // 如果只有一种存储器类型，则自动选择
-        if (this.availableMemoryTypes.length === 1) {
-          this.setSelectedMemoryType(this.availableMemoryTypes[0]);
+        const memoryTypes = getSupportedMemoryTypes(chip.id);
+        if (!this.selectedMemoryType || !memoryTypes.includes(this.selectedMemoryType)) {
+          this.setSelectedMemoryType(memoryTypes[0] || null);
+        } else {
+          this.memoryTypeInput = this.selectedMemoryType;
+          this.tempMemoryTypeInput = this.selectedMemoryType;
+        }
+
+        const interfaces = getSupportedInterfaces(chip.id);
+        if (!interfaces.includes(this.selectedInterface)) {
+          this.setSelectedInterface(interfaces[0] || 'UART');
         }
       }
       this.saveToStorage();
     },
 
     // 设置存储器类型
-    setSelectedMemoryType(memoryType: string | null) {
+    setSelectedMemoryType(memoryType: MemoryType | null) {
       this.selectedMemoryType = memoryType;
       if (memoryType) {
         this.memoryTypeInput = memoryType;
+        this.tempMemoryTypeInput = memoryType;
+      } else {
+        this.memoryTypeInput = '';
+        this.tempMemoryTypeInput = '';
       }
       this.saveToStorage();
     },
 
     // 设置接口类型
     setSelectedInterface(interfaceType: string) {
-      this.selectedInterface = interfaceType;
-      if (interfaceType !== 'UART') {
+      const selectedInterface = interfaceType as InterfaceType;
+      if (!this.availableInterfaces.includes(selectedInterface)) return;
+
+      this.selectedInterface = selectedInterface;
+      if (selectedInterface !== 'UART') {
         // 如果不是UART接口，重置串口和波特率
         this.selectedPort = null;
         this.portSearchInput = '';
@@ -323,9 +339,12 @@ export const useDeviceStore = defineStore('device', {
         // 加载存储器类型
         const memoryTypeData = await storeInstance.get('selectedMemoryType');
         if (memoryTypeData?.value) {
-          this.selectedMemoryType = memoryTypeData.value;
-          this.memoryTypeInput = memoryTypeData.value;
-          this.tempMemoryTypeInput = memoryTypeData.value;
+          const memoryType = memoryTypeData.value as MemoryType;
+          if (this.availableMemoryTypes.includes(memoryType)) {
+            this.selectedMemoryType = memoryType;
+            this.memoryTypeInput = memoryType;
+            this.tempMemoryTypeInput = memoryType;
+          }
         } else if (this.availableMemoryTypes.length > 0) {
           // 默认选择第一个可用的存储器类型
           this.selectedMemoryType = this.availableMemoryTypes[0];
@@ -335,8 +354,10 @@ export const useDeviceStore = defineStore('device', {
 
         // 加载接口类型
         const interfaceData = await storeInstance.get('selectedInterface');
-        if (interfaceData?.value) {
+        if (interfaceData?.value && this.availableInterfaces.includes(interfaceData.value)) {
           this.selectedInterface = interfaceData.value;
+        } else if (!this.availableInterfaces.includes(this.selectedInterface) && this.availableInterfaces.length > 0) {
+          this.selectedInterface = this.availableInterfaces[0];
         }
 
         // 加载串口设置


### PR DESCRIPTION
## Summary
- Restrict chip memory and interface options to supported combinations.
- Improve connection failure prompts and related log output.
- Add chip support validation coverage script.

## Validation
- pnpm i18n:check
- pnpm lint
- pnpm build